### PR TITLE
adds ability to have versions in an "/bin/archived" folder

### DIFF
--- a/build/build-bundle.xml
+++ b/build/build-bundle.xml
@@ -185,8 +185,17 @@
           </antcall>
         </then>
       </elseif>
+      <elseif>
+        <available file="${project.basedir}\bin\archived\${bundle.name}${input.bundle}" type="dir"/>
+        <then>
+          <echo message="Bundle version found in archived location: ${project.basedir}\bin\archived\${bundle.name}${input.bundle}"/>
+          <antcall target="release.one">
+            <param name="bundle.path" value="${project.basedir}\bin\archived\${bundle.name}${input.bundle}"/>
+          </antcall>
+        </then>
+      </elseif>
       <else>
-        <fail message="Invalid bundle's version for ${bundle.name}"/>
+        <fail message="Invalid bundle's version for ${bundle.name}. Checked both /bin/ and /bin/archived/ locations."/>
       </else>
     </if>
   </target>


### PR DESCRIPTION
### **User description**
adds ability to have versions in an "/bin/archived" folder and still do a release.


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for archived bundle versions in `/bin/archived/` folder

- Enhance build system to check archived location during release

- Improve error messaging for bundle version lookup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bundle Release Request"] --> B["Check /bin/ folder"]
  B --> C{Bundle Found?}
  C -->|Yes| D["Release Bundle"]
  C -->|No| E["Check /bin/archived/ folder"]
  E --> F{Bundle Found?}
  F -->|Yes| G["Release Archived Bundle"]
  F -->|No| H["Fail with Enhanced Error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-bundle.xml</strong><dd><code>Enhanced bundle lookup with archived support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build/build-bundle.xml

<ul><li>Add new elseif condition to check <code>/bin/archived/</code> directory<br> <li> Include echo message for archived bundle detection<br> <li> Update error message to mention both checked locations</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/dev/pull/35/files#diff-0587dc0ba27982b85a36cf4c9e56bf6cc46c4c8f19fda0bc036cc8f6153b70f8">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

